### PR TITLE
improve encoder and decoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ clean:
 	@dune clean
 
 test:
-	@dune runtest $(DUNE_OPTS)
+	@dune runtest $(DUNE_OPTS) -f
 
 doc:
 	@dune build $(DUNE_OPTS) @doc
@@ -17,7 +17,7 @@ build-dev:
 
 WATCH?= @check @runtest
 watch:
-	dune build $(DUNE_OPTS) -w $(WATCH)
+	dune build $(DUNE_OPTS) -w $(WATCH) -f
 
 DUNE_OPTS_BENCH?=--profile=release
 

--- a/bench_basic1.sh
+++ b/bench_basic1.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+OPTS="--display=quiet --profile=release"
+exec dune exec $OPTS benchs/basic1/run.exe -- $@

--- a/benchs/basic1/run.ml
+++ b/benchs/basic1/run.ml
@@ -89,7 +89,7 @@ module Dec = struct
             Printf.printf "size for n=%d, depth=%d: %d B\n" n depth
               (String.length str);
 
-            let run_ref v () =
+            let run_ref str () =
               ignore (Sys.opaque_identity (CB_ref.decode_exn str) : CB_ref.t)
             in
 
@@ -107,7 +107,7 @@ module Dec = struct
 
             B.throughputN ~repeat:2 3
               [
-                "ref", run_ref v, ();
+                "ref", run_ref str, ();
                 "ccbor_tree", run_ccbor_tree str, ();
                 "ccbor_skip", run_ccbor_skip str, ();
               ]))

--- a/benchs/basic1/run.ml
+++ b/benchs/basic1/run.ml
@@ -54,7 +54,7 @@ let bench ~n ~depth : B.Tree.t =
 
           let enc = Ccbor.Encoder.create () in
           let run_ccbor enc () =
-            Ccbor.Encoder.reset enc;
+            Ccbor.Encoder.clear enc;
             ccbor_encode enc ~n ~depth
           in
 

--- a/benchs/basic1/run.ml
+++ b/benchs/basic1/run.ml
@@ -39,38 +39,86 @@ let rec ccbor_encode (enc : Ccbor.Encoder.t) ~n ~depth : unit =
     enc_rec enc i
   done
 
-let bench ~n ~depth : B.Tree.t =
-  B.Tree.(
-    spf "n=%n,d=%d" n depth
-    @> lazy
-         (let v = mk_val ~n ~depth in
-          let str = CB_ref.encode v in
-          Printf.printf "size for n=%d, depth=%d: %d B\n" n depth
-            (String.length str);
+let ccbor_decode_skip (dec : Ccbor.Decoder.t) : unit =
+  let module CD = Ccbor.Decoder in
+  CD.skip_tree dec
 
-          let run_ref v () =
-            ignore (Sys.opaque_identity (CB_ref.encode v) : string)
-          in
+module Enc = struct
+  let bench ~n ~depth : B.Tree.t =
+    B.Tree.(
+      spf "n=%n,d=%d" n depth
+      @> lazy
+           (let v = mk_val ~n ~depth in
+            let str = CB_ref.encode v in
+            Printf.printf "size for n=%d, depth=%d: %d B\n" n depth
+              (String.length str);
 
-          let enc = Ccbor.Encoder.create () in
-          let run_ccbor enc () =
-            Ccbor.Encoder.clear enc;
-            ccbor_encode enc ~n ~depth
-          in
+            let run_ref v () =
+              ignore (Sys.opaque_identity (CB_ref.encode v) : string)
+            in
 
-          run_ccbor enc ();
-          Printf.printf "ccbor size for n=%d, depth=%d: %d B\n" n depth
-            (Ccbor.Encoder.total_size enc);
+            let enc = Ccbor.Encoder.create () in
+            let run_ccbor enc () =
+              Ccbor.Encoder.clear enc;
+              ccbor_encode enc ~n ~depth
+            in
 
-          B.throughputN ~repeat:2 3
-            [ "ref", run_ref v, (); "ccbor", run_ccbor enc, () ]))
+            run_ccbor enc ();
+            Printf.printf "ccbor size for n=%d, depth=%d: %d B\n" n depth
+              (Ccbor.Encoder.total_size enc);
 
-let () =
-  B.Tree.(
-    register @@ "enc"
-    @>> concat
-          (List.map
-             (fun (n, depth) -> bench ~n ~depth)
-             [ 1, 1; 2, 1; 2, 2; 2, 3; 10, 1; 10, 2; 10, 3; 100, 1; 100, 2 ]))
+            B.throughputN ~repeat:2 3
+              [ "ref", run_ref v, (); "ccbor", run_ccbor enc, () ]))
+
+  let () =
+    B.Tree.(
+      register @@ "enc"
+      @>> concat
+            (List.map
+               (fun (n, depth) -> bench ~n ~depth)
+               [ 1, 1; 2, 1; 2, 2; 2, 3; 10, 1; 10, 2; 10, 3; 100, 1; 100, 2 ]))
+end
+
+module Dec = struct
+  let bench ~n ~depth : B.Tree.t =
+    B.Tree.(
+      spf "n=%n,d=%d" n depth
+      @> lazy
+           (let v = mk_val ~n ~depth in
+            let str = CB_ref.encode v in
+            Printf.printf "size for n=%d, depth=%d: %d B\n" n depth
+              (String.length str);
+
+            let run_ref v () =
+              ignore (Sys.opaque_identity (CB_ref.decode_exn str) : CB_ref.t)
+            in
+
+            let run_ccbor_tree str () : unit =
+              let dec = Ccbor.Decoder.create_string str in
+              ignore
+                (Sys.opaque_identity
+                   (Ccbor.Decoder.read_tree dec : Ccbor.Tree.t))
+            in
+
+            let run_ccbor_skip str () : unit =
+              let dec = Ccbor.Decoder.create_string str in
+              Sys.opaque_identity (ccbor_decode_skip dec)
+            in
+
+            B.throughputN ~repeat:2 3
+              [
+                "ref", run_ref v, ();
+                "ccbor_tree", run_ccbor_tree str, ();
+                "ccbor_skip", run_ccbor_skip str, ();
+              ]))
+
+  let () =
+    B.Tree.(
+      register @@ "dec"
+      @>> concat
+            (List.map
+               (fun (n, depth) -> bench ~n ~depth)
+               [ 1, 1; 2, 1; 2, 2; 2, 3; 10, 1; 10, 2; 10, 3; 100, 1; 100, 2 ]))
+end
 
 let () = B.Tree.(run_global ())

--- a/ccbor.opam
+++ b/ccbor.opam
@@ -8,6 +8,7 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.08"}
   "containers" {>= "3.0" & with-test}
+  "qcheck-core" {>= "0.14" & with-test}
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -11,4 +11,5 @@
   (depends
     dune
     (ocaml (>= 4.08))
-    (containers (and (>= 3.0) :with-test))))
+    (containers (and (>= 3.0) :with-test))
+    (qcheck-core (and (>= 0.14) :with-test))))

--- a/src/ccbor.ml
+++ b/src/ccbor.ml
@@ -1,1 +1,5 @@
+(** A CBOR codec with an emphasis on performance. *)
+
 module Encoder = Encoder
+module Decoder = Decoder
+module Tree = Tree

--- a/src/decoder.ml
+++ b/src/decoder.ml
@@ -12,6 +12,10 @@ let create_sub b i len =
 
 let create b : t = create_sub b 0 (Bytes.length b)
 
+let create_string s : t = create (Bytes.unsafe_of_string s)
+
+let create_string_sub s i len : t = create_sub (Bytes.unsafe_of_string s) i len
+
 let[@inline] check_non_empty (self : t) : unit =
   if self.i >= self.last then raise End_of_file
 

--- a/src/decoder.ml
+++ b/src/decoder.ml
@@ -16,32 +16,29 @@ let create_string s : t = create (Bytes.unsafe_of_string s)
 
 let create_string_sub s i len : t = create_sub (Bytes.unsafe_of_string s) i len
 
-let[@inline] check_non_empty (self : t) : unit =
-  if self.i >= self.last then raise End_of_file
-
 let[@inline] check_has_at_least (self : t) n : unit =
   if self.i + n > self.last then raise End_of_file
 
 let[@inline] read_i8 (self : t) =
-  check_non_empty self;
+  (* check_has_at_least self 1; *)
   let c = Char.code (Bytes.get self.b self.i) in
   self.i <- 1 + self.i;
   c
 
-let[@inline] read_i16 (self : t) =
-  check_has_at_least self 2;
+let read_i16 (self : t) =
+  (* check_has_at_least self 2; *)
   let c = Bytes.get_uint16_be self.b self.i in
   self.i <- self.i + 2;
   c
 
 let[@inline] read_i32 (self : t) =
-  check_has_at_least self 4;
+  (* check_has_at_least self 4; *)
   let c = Bytes.get_int32_be self.b self.i in
   self.i <- self.i + 4;
   c
 
 let[@inline] read_i64 (self : t) =
-  check_has_at_least self 8;
+  (* check_has_at_least self 8; *)
   let c = Bytes.get_int64_be self.b self.i in
   self.i <- self.i + 8;
   c
@@ -52,6 +49,9 @@ let[@inline] i64_to_int i =
     j
   else
     failwith "int64 does not fit in int"
+
+let[@inline] int64_fits_in_int_ (i : int64) : bool =
+  Int64.(of_int (to_int i) = i)
 
 let[@inline] int_is_small ~low : bool = low <= 25
 
@@ -176,11 +176,20 @@ let next_token (self : t) : token =
   | 0 ->
     if int_is_small ~low then
       Int (read_small_int self ~low)
-    else
-      Int64 (read_int64 self ~allow_indefinite:false ~low)
+    else (
+      let i = read_int64 self ~allow_indefinite:false ~low in
+      if int64_fits_in_int_ i then
+        Int (Int64.to_int i)
+      else
+        Int64 i
+    )
   | 1 ->
     let i = read_int64 self ~allow_indefinite:false ~low in
-    Int64 Int64.(sub minus_one i)
+    let i = Int64.(sub minus_one i) in
+    if int64_fits_in_int_ i then
+      Int (Int64.to_int i)
+    else
+      Int64 i
   | 2 -> read_bytes self ~ty:T_bytes ~low
   | 3 -> read_bytes self ~ty:T_text ~low
   | 4 -> read_array self ~low
@@ -238,8 +247,8 @@ let rec read_tree (self : t) : Tree.t =
   | False -> T.Bool false
   | Null -> T.Null
   | Undefined -> T.Undefined
-  | Int i -> T.Int (Int64.of_int i)
-  | Int64 i -> T.Int i
+  | Int i -> T.Int i
+  | Int64 i -> T.Int64 i
   | Simple i -> T.Simple i
   | Float f -> T.Float f
   | Bytes (b, i, len) -> T.Bytes (bytes_sub_ b i len |> Bytes.unsafe_to_string)

--- a/src/decoder.mli
+++ b/src/decoder.mli
@@ -4,6 +4,10 @@ val create : bytes -> t
 
 val create_sub : bytes -> int -> int -> t
 
+val create_string : string -> t
+
+val create_string_sub : string -> int -> int -> t
+
 type token =
   | True
   | False

--- a/src/dune
+++ b/src/dune
@@ -1,8 +1,8 @@
 (library
   (public_name ccbor)
-  ;(foreign_stubs
-  ;  (language c)
-  ;  (flags :standard -std=c99 -O2)
-  ;  (names stubs))
+  (foreign_stubs
+    (language c)
+    (flags :standard -std=c99 -O2)
+    (names stubs))
   (ocamlopt_flags :standard -inline 100))
 

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -4,15 +4,16 @@ type chunk = {
 }
 (** A chunk of data *)
 
+(** chunks of a fixed size *)
+let default_chunk_size = 256
+
 type t = {
   mutable cur: chunk;  (** Current chunk, not full *)
+  chunk_size: int;
   mutable prev_chunks: chunk list;
       (** list of previous chunks, most recent first *)
   mutable reuse_chunks: chunk list;  (** Chunks we can reuse *)
 }
-
-(** chunks of 1kiB *)
-let chunk_size = 1 * 1024
 
 module Chunk = struct
   type t = chunk
@@ -24,7 +25,7 @@ module Chunk = struct
 
   let[@inline] has_space_ (self : t) : bool = Bytes.length self.bs <> self.off
 
-  let[@inline] create () : t = { bs = Bytes.create chunk_size; off = 0 }
+  let[@inline] create ~size () : t = { bs = Bytes.create size; off = 0 }
 end
 
 let total_size (self : t) : int =
@@ -32,8 +33,13 @@ let total_size (self : t) : int =
     (fun acc c -> acc + Chunk.size c)
     (Chunk.size self.cur) self.prev_chunks
 
-let create () : t =
-  { cur = Chunk.create (); prev_chunks = []; reuse_chunks = [] }
+let create ?(chunk_size = default_chunk_size) () : t =
+  {
+    cur = Chunk.create ~size:chunk_size ();
+    chunk_size;
+    prev_chunks = [];
+    reuse_chunks = [];
+  }
 
 let[@inline] clear_chunk_ (c : Chunk.t) = c.off <- 0
 
@@ -43,27 +49,51 @@ let clear (self : t) =
   self.reuse_chunks <- self.prev_chunks;
   self.prev_chunks <- []
 
-let reset (self : t) =
+let[@inline] reset (self : t) =
   clear_chunk_ self.cur;
   self.prev_chunks <- []
 
-let rec list_rev_iter_ f st l =
+let[@unroll 2] rec list_rev_iter_ f st l =
   match l with
   | [] -> ()
   | x :: tl ->
     list_rev_iter_ f st tl;
     f st x
 
-let iter_chunks (self : t) yield : unit =
-  list_rev_iter_ (fun k c -> k c.bs 0 c.off) yield self.prev_chunks;
+let[@inline] iter_chunks (self : t) yield : unit =
+  if self.prev_chunks != [] then
+    list_rev_iter_ (fun k c -> k c.bs 0 c.off) yield self.prev_chunks;
   yield self.cur.bs 0 self.cur.off
+
+module To_string_ = struct
+  type state = {
+    res: bytes;
+    mutable off: int;
+  }
+
+  let add_chunk (self : state) (c : Chunk.t) : unit =
+    Bytes.blit c.bs 0 self.res self.off c.off;
+    self.off <- self.off + c.off
+
+  let to_string (self : state) : string =
+    assert (self.off = Bytes.length self.res);
+    Bytes.unsafe_to_string self.res
+end
+
+let to_string (self : t) : string =
+  let size = total_size self in
+  let st = { To_string_.res = Bytes.create size; off = 0 } in
+  if self.prev_chunks != [] then
+    list_rev_iter_ To_string_.add_chunk st self.prev_chunks;
+  To_string_.add_chunk st self.cur;
+  To_string_.to_string st
 
 (* ### encoding proper ### *)
 
 external encode_uint_with_high :
   bytes ->
   (int[@untagged]) ->
-  (int[@untagged]) ->
+  high:(int[@untagged]) ->
   (int[@untagged]) ->
   (int[@untagged]) = "caml_ccbor_encode_uint_byte" "caml_ccbor_encode_uint"
   [@@noalloc]
@@ -84,7 +114,7 @@ let[@inline never] alloc_new_chunk_ (self : t) : chunk =
   self.prev_chunks <- self.cur :: self.prev_chunks;
   let c =
     match self.reuse_chunks with
-    | [] -> Chunk.create ()
+    | [] -> Chunk.create ~size:self.chunk_size ()
     | c :: tl ->
       (* reuse [c] *)
       self.reuse_chunks <- tl;
@@ -138,12 +168,12 @@ let[@inline] int (self : t) (i : int) =
   let size = encode_int c.bs c.off (Int64.of_int i) in
   c.off <- c.off + size
 
-let add_int_unsigned (self : t) high (i : int) : unit =
+let add_int_unsigned (self : t) ~high (i : int) : unit =
   let c = get_space_for_small_ self 9 in
-  let size = encode_uint_with_high c.bs c.off high i in
+  let size = encode_uint_with_high c.bs c.off ~high i in
   c.off <- c.off + size
 
-let rec add_bytes (self : t) bs i len : unit =
+let rec add_bytes_slice_ (self : t) bs i len : unit =
   if len > 0 then (
     let chunk = get_chunk_with_space self in
     let free = Chunk.free_size_ chunk in
@@ -156,67 +186,65 @@ let rec add_bytes (self : t) bs i len : unit =
       Bytes.blit bs i chunk.bs chunk.off free;
       chunk.off <- chunk.off + free;
       (* write the rest recursively *)
-      add_bytes self bs (i + free) (len - free)
+      add_bytes_slice_ self bs (i + free) (len - free)
     )
   )
 
-let bytes self bs i len : unit =
-  add_int_unsigned self 2 len;
-  add_bytes self bs i len
+let bytes_sub self bs i len : unit =
+  add_int_unsigned self ~high:2 len;
+  add_bytes_slice_ self bs i len
+
+let bytes self b = bytes_sub self b 0 (Bytes.length b)
 
 let text_sub self s i len : unit =
-  add_int_unsigned self 3 len;
-  add_bytes self (Bytes.unsafe_of_string s) i len
+  add_int_unsigned self ~high:3 len;
+  add_bytes_slice_ self (Bytes.unsafe_of_string s) i len
 
-let text self s : unit = text_sub self s 0 (String.length s)
+let[@inline] text self s : unit = text_sub self s 0 (String.length s)
 
-let array_enter (self : t) (n : int) : unit = add_int_unsigned self 4 n
+let[@inline] array_enter (self : t) (n : int) : unit =
+  add_int_unsigned self ~high:4 n
 
-let map_enter (self : t) (n : int) : unit = add_int_unsigned self 5 n
+let[@inline] map_enter (self : t) (n : int) : unit =
+  add_int_unsigned self ~high:5 n
 
-(* TODO: simple *)
-(* TODO: float *)
-(* TODO: tag *)
+let[@inline] simple (self : t) (x : int) : unit =
+  add_int_unsigned self ~high:7 x
 
-(*
+let float (self : t) (f : float) : unit =
+  add_first_byte self 7 27;
+  let c = get_space_for_small_ self 8 in
+  Bytes.set_int64_be c.bs c.off (Int64.bits_of_float f);
+  c.off <- c.off + 8
 
-  let rec encode_val (self : t) : unit =
-    match self with
-    | `Simple i ->
-      if i < 24 then
-        add_first_byte 7 i
-      else if i <= 0xff then (
-        add_first_byte 7 24;
-        Buffer.add_char buf (Char.unsafe_chr i)
-      ) else
-        failwith "cbor: simple value too high (above 255)"
-    | `Float f ->
-      add_first_byte 7 27;
-      (* float 64 *)
-      add_i64 (Int64.bits_of_float f)
-    | `Array l ->
-      add_uint 4 (Int64.of_int (List.length l));
-      List.iter encode_val l
-    | `Map l ->
-      add_uint 5 (Int64.of_int (List.length l));
-      List.iter
-        (fun (k, v) ->
-          encode_val k;
-          encode_val v)
-        l
-    | `Tag (t, v) ->
-      add_uint 6 (Int64.of_int t);
-      encode_val v
-    | `Int i ->
-      if i >= Int64.zero then
-        add_uint 0 i
-      else if Int64.(add min_int 2L) > i then (
-        (* large negative int, be careful. encode [(-i)-1] via int64. *)
-        add_first_byte 1 27;
-        Buffer.add_int64_be buf Int64.(neg (add 1L i))
-      ) else
-        add_uint 1 Int64.(sub (neg i) one)
-  in
-  encode_val self;
-  Buffer.contents buf
-  *)
+let[@inline] tag_enter (self : t) (tag : int) : unit =
+  add_int_unsigned self ~high:6 tag
+
+let rec add_tree (self : t) (t : Tree.t) : unit =
+  match t with
+  | Tree.Null -> null self
+  | Tree.Undefined -> undefined self
+  | Tree.Simple i -> simple self i
+  | Tree.Bool b -> bool self b
+  | Tree.Int i -> int64 self i
+  | Tree.Float f -> float self f
+  | Tree.Bytes b ->
+    let b = Bytes.unsafe_of_string b in
+    bytes self b
+  | Tree.Text s -> text self s
+  | Tree.Array a ->
+    array_enter self (Array.length a);
+    for i = 0 to Array.length a - 1 do
+      let x = Array.unsafe_get a i in
+      add_tree self x
+    done
+  | Tree.Map m ->
+    map_enter self (Array.length m);
+    for i = 0 to Array.length m - 1 do
+      let k, v = Array.unsafe_get m i in
+      add_tree self k;
+      add_tree self v
+    done
+  | Tree.Tag (tag, t) ->
+    tag_enter self tag;
+    add_tree self t

--- a/src/encoder.ml
+++ b/src/encoder.ml
@@ -226,7 +226,8 @@ let rec add_tree (self : t) (t : Tree.t) : unit =
   | Tree.Undefined -> undefined self
   | Tree.Simple i -> simple self i
   | Tree.Bool b -> bool self b
-  | Tree.Int i -> int64 self i
+  | Tree.Int i -> int self i
+  | Tree.Int64 i -> int64 self i
   | Tree.Float f -> float self f
   | Tree.Bytes b ->
     let b = Bytes.unsafe_of_string b in

--- a/src/encoder.mli
+++ b/src/encoder.mli
@@ -1,6 +1,9 @@
 type t
+(** Encoder. It accumulates bytes that form a CBOR value. *)
 
-val create : unit -> t
+(** {2 Encoder} *)
+
+val create : ?chunk_size:int -> unit -> t
 
 val clear : t -> unit
 
@@ -8,7 +11,12 @@ val reset : t -> unit
 
 val iter_chunks : t -> (bytes -> int -> int -> unit) -> unit
 
+val to_string : t -> string
+(** Build a string containing all the bytes so far. This always allocates. *)
+
 val total_size : t -> int
+
+(** {2 Encoding values} *)
 
 val bool : t -> bool -> unit
 
@@ -20,7 +28,11 @@ val int : t -> int -> unit
 
 val int64 : t -> int64 -> unit
 
-val bytes : t -> bytes -> int -> int -> unit
+val float : t -> float -> unit
+
+val bytes : t -> bytes -> unit
+
+val bytes_sub : t -> bytes -> int -> int -> unit
 
 val text : t -> string -> unit
 
@@ -29,3 +41,8 @@ val text_sub : t -> string -> int -> int -> unit
 val array_enter : t -> int -> unit
 
 val map_enter : t -> int -> unit
+
+val simple : t -> int -> unit
+
+val add_tree : t -> Tree.t -> unit
+(** Encode the whole subtree *)

--- a/src/encoder.mli
+++ b/src/encoder.mli
@@ -2,6 +2,8 @@ type t
 
 val create : unit -> t
 
+val clear : t -> unit
+
 val reset : t -> unit
 
 val iter_chunks : t -> (bytes -> int -> int -> unit) -> unit

--- a/src/stubs.c
+++ b/src/stubs.c
@@ -42,11 +42,11 @@ static int encode_uint_with_mask(char *bs, int high, uint64_t x) {
 }
 
 static int encode_int(char *bs, int64_t x) {
-  int high = 1;
+  int high = 0;
   uint64_t ux;
 
   if (x < 0) {
-    high = 0;
+    high = 1;
     ux = (uint64_t)(-x - 1);
 
   } else {
@@ -56,7 +56,7 @@ static int encode_int(char *bs, int64_t x) {
   return encode_uint_with_mask(bs, high, ux);
 }
 
-int caml_ccbor_encode_int(value bs_, int off, int64_t x) {
+intnat caml_ccbor_encode_int(value bs_, intnat off, int64_t x) {
   char *bs = Bytes_val(bs_);
   return encode_int(bs + off, x);
 }
@@ -67,15 +67,15 @@ value caml_ccbor_encode_int_byte(value bs_, value off_, value x_) {
   CAMLreturn(x);
 }
 
-int caml_ccbor_encode_uint(value bs_, int off, int high, int64_t x) {
+intnat caml_ccbor_encode_uint(value bs_, intnat off, intnat high, intnat x) {
   char *bs = Bytes_val(bs_);
-  return encode_uint_with_mask(bs + off, high, x);
+  return (long)encode_uint_with_mask(bs + off, high, x);
 }
 
 value caml_ccbor_encode_uint_byte(value bs_, value off_, value high_,
                                   value x_) {
   CAMLparam4(bs_, off_, high_, x_);
   int x = encode_uint_with_mask(Bytes_val(bs_) + Int_val(off_), Int_val(high_),
-                                Int64_val(x_));
-  CAMLreturn(x);
+                                Int_val(x_));
+  CAMLreturn(Val_int(x));
 }

--- a/src/stubs.c
+++ b/src/stubs.c
@@ -1,0 +1,81 @@
+
+#include <caml/alloc.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define FIRST_BYTE(high, low) ((high) << 5 | low)
+
+static int encode_uint_with_mask(char *bs, int high, uint64_t x) {
+  if (x < 24) {
+    bs[0] = FIRST_BYTE(high, x);
+    return 1;
+  } else if (x <= 0xff) {
+    bs[0] = FIRST_BYTE(high, 24);
+    bs[1] = x;
+    return 2;
+  } else if (x <= 0xffff) {
+    bs[0] = FIRST_BYTE(high, 25);
+    bs[1] = (x >> 8);
+    bs[2] = (x & 0xff);
+    return 3;
+  } else if (x <= 0xffffffff) {
+    bs[0] = FIRST_BYTE(high, 26);
+    bs[1] = (x >> 24);
+    bs[2] = ((x >> 16) & 0xff);
+    bs[3] = ((x >> 8) & 0xff);
+    bs[4] = (x & 0xff);
+    return 5;
+  } else {
+    bs[0] = FIRST_BYTE(high, 27);
+    bs[1] = (x >> 56);
+    bs[2] = ((x >> 48) & 0xff);
+    bs[3] = ((x >> 40) & 0xff);
+    bs[4] = ((x >> 32) & 0xff);
+    bs[5] = ((x >> 24) & 0xff);
+    bs[6] = ((x >> 16) & 0xff);
+    bs[7] = ((x >> 8) & 0xff);
+    bs[8] = (x & 0xff);
+    return 9;
+  }
+}
+
+static int encode_int(char *bs, int64_t x) {
+  int high = 1;
+  uint64_t ux;
+
+  if (x < 0) {
+    high = 0;
+    ux = (uint64_t)(-x - 1);
+
+  } else {
+    ux = (uint64_t)x;
+  }
+
+  return encode_uint_with_mask(bs, high, ux);
+}
+
+int caml_ccbor_encode_int(value bs_, int off, int64_t x) {
+  char *bs = Bytes_val(bs_);
+  return encode_int(bs + off, x);
+}
+
+value caml_ccbor_encode_int_byte(value bs_, value off_, value x_) {
+  CAMLparam3(bs_, off_, x_);
+  int x = encode_int(Bytes_val(bs_) + Int_val(off_), Int64_val(x_));
+  CAMLreturn(x);
+}
+
+int caml_ccbor_encode_uint(value bs_, int off, int high, int64_t x) {
+  char *bs = Bytes_val(bs_);
+  return encode_uint_with_mask(bs + off, high, x);
+}
+
+value caml_ccbor_encode_uint_byte(value bs_, value off_, value high_,
+                                  value x_) {
+  CAMLparam4(bs_, off_, high_, x_);
+  int x = encode_uint_with_mask(Bytes_val(bs_) + Int_val(off_), Int_val(high_),
+                                Int64_val(x_));
+  CAMLreturn(x);
+}

--- a/src/tree.ml
+++ b/src/tree.ml
@@ -3,7 +3,8 @@ type t =
   | Undefined
   | Simple of int
   | Bool of bool
-  | Int of int64
+  | Int of int
+  | Int64 of int64
   | Float of float
   | Bytes of string
   | Text of string
@@ -32,7 +33,8 @@ let rec pp out (self : t) =
   | Undefined -> Format.pp_print_string out "undefined"
   | Simple i -> Format.fprintf out "simple(%d)" i
   | Bool b -> Format.pp_print_bool out b
-  | Int i -> Format.fprintf out "%Ld" i
+  | Int i -> Format.fprintf out "%d" i
+  | Int64 i -> Format.fprintf out "%LdL" i
   | Float f -> Format.pp_print_float out f
   | Bytes s -> Format.fprintf out "h'%s'" (hex_of_string s)
   | Text s -> Format.fprintf out "%S" s

--- a/src/tree.mli
+++ b/src/tree.mli
@@ -3,7 +3,8 @@ type t =
   | Undefined
   | Simple of int
   | Bool of bool
-  | Int of int64
+  | Int of int
+  | Int64 of int64
   | Float of float
   | Bytes of string
   | Text of string

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+
+(test
+  (name tests)
+  (libraries ccbor ccbor_reference qcheck-core qcheck-core.runner))

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -1,0 +1,184 @@
+module Q = QCheck
+module CBRef = Ccbor_reference
+module C = Ccbor
+
+let qsuite = ref []
+
+let add_qtest ?name ?count ?long_factor gen prop =
+  qsuite := Q.Test.make ?name ?count ?long_factor gen prop :: !qsuite
+
+let hex_of_string (s : string) : string =
+  let i_to_hex (i : int) =
+    if i < 10 then
+      Char.chr (i + Char.code '0')
+    else
+      Char.chr (i - 10 + Char.code 'a')
+  in
+  let res = Bytes.create (2 * String.length s) in
+  for i = 0 to String.length s - 1 do
+    let n = Char.code (String.get s i) in
+    Bytes.set res (2 * i) (i_to_hex ((n land 0xf0) lsr 4));
+    Bytes.set res ((2 * i) + 1) (i_to_hex (n land 0x0f))
+  done;
+  Bytes.unsafe_to_string res
+
+module Util_tree = struct
+  open C.Tree
+
+  let equal (t1 : t) (t2 : t) : bool = t1 = t2
+
+  let rec shrink (self : t) : t Q.Iter.t =
+    let open Q.Iter in
+    match self with
+    | Null | Undefined | Simple _ | Bool false -> empty
+    | Float _ -> empty
+    | Bool true -> return (Bool false)
+    | Int i -> Q.Shrink.int64 i >|= fun i -> Int i
+    | Bytes s -> Q.Shrink.string s >|= fun s -> Bytes s
+    | Text s -> Q.Shrink.string s >|= fun s -> Text s
+    | Array a ->
+      (* return each elem, or shrink array *)
+      (fun yield -> Array.iter (fun x -> yield x) a)
+      <+> (Q.Shrink.array ~shrink a >|= fun a -> Array a)
+    | Map m ->
+      (fun yield ->
+        Array.iter
+          (fun (k, v) ->
+            yield k;
+            yield v)
+          m)
+      <+> ( Q.Shrink.array ~shrink:(Q.Shrink.pair shrink shrink) m >|= fun m ->
+            Map m )
+    | Tag (tag, v) ->
+      return v
+      <+> (Q.Shrink.int tag >|= fun tag -> Tag (tag, v))
+      <+> (shrink v >|= fun v -> Tag (tag, v))
+
+  let rec of_ref (r : CBRef.t) : t =
+    match r with
+    | `Bool b -> Bool b
+    | `Simple i -> Simple i
+    | `Tag (tag, v) -> Tag (tag, of_ref v)
+    | `Null -> Null
+    | `Array l -> Array (Array.of_list l |> Array.map of_ref)
+    | `Map m -> Map (Array.of_list m |> Array.map (CCPair.map_same of_ref))
+    | `Bytes s -> Bytes s
+    | `Float f -> Float f
+    | `Int i -> Int i
+    | `Undefined -> Undefined
+    | `Text s -> Text s
+
+  let rec to_ref (r : t) : CBRef.t =
+    match r with
+    | Bool b -> `Bool b
+    | Simple i -> `Simple i
+    | Tag (tag, v) -> `Tag (tag, to_ref v)
+    | Null -> `Null
+    | Array l -> `Array (Array.to_list l |> List.map to_ref)
+    | Map m -> `Map (Array.to_list m |> List.map (CCPair.map_same to_ref))
+    | Bytes s -> `Bytes s
+    | Float f -> `Float f
+    | Int i -> `Int i
+    | Undefined -> `Undefined
+    | Text s -> `Text s
+end
+
+let gen_tree : C.Tree.t Q.Gen.t =
+  Q.Gen.(
+    let module T = C.Tree in
+    sized @@ fix
+    @@ fun self_ depth ->
+    let base =
+      [
+        1, return T.Null;
+        1, return T.Undefined;
+        (1, float >|= fun f -> T.Float f);
+        (1, bool >|= fun b -> T.Bool b);
+        (2, -1000 -- 1000 >|= fun x -> T.Int (Int64.of_int x));
+        (2, 0 -- 19 >|= fun x -> T.Simple x);
+        (2, string_size ~gen:printable (0 -- 300) >|= fun s -> T.Text s);
+        (2, string_size (0 -- 300) >|= fun s -> T.Bytes s);
+      ]
+    in
+    let rec_ =
+      [
+        (1, array_size (0 -- 15) (self_ (depth / 2)) >|= fun a -> T.Array a);
+        ( 1,
+          array_size (0 -- 15) (pair (self_ 0) (self_ (depth / 3))) >|= fun m ->
+          T.Map m );
+        ( 1,
+          0 -- 500 >>= fun tag ->
+          self_ (depth - 1) >|= fun sub -> T.Tag (tag, sub) );
+      ]
+    in
+    if depth = 0 then
+      frequency base
+    else
+      frequency (base @ rec_))
+
+let arb_tree : C.Tree.t Q.arbitrary =
+  Q.make ~shrink:Util_tree.shrink ~print:C.Tree.show gen_tree
+
+let () =
+  add_qtest ~name:"encode_then_refdecode" ~count:1000 arb_tree (fun t ->
+      let encoded =
+        let enc = C.Encoder.create () in
+        C.Encoder.add_tree enc t;
+        C.Encoder.to_string enc
+      in
+
+      let decoded =
+        let t_ref = CBRef.decode_exn encoded in
+        Util_tree.of_ref t_ref
+      in
+
+      if not @@ Util_tree.equal t decoded then
+        Q.Test.fail_reportf
+          "initial: %a@ decoded(encoded(.)): %a@ :raw-encoded h'%s'" C.Tree.pp t
+          C.Tree.pp decoded (hex_of_string encoded);
+
+      true)
+
+let () =
+  add_qtest ~name:"encode_then_decode" ~count:1000 arb_tree (fun t ->
+      let encoded =
+        let enc = C.Encoder.create () in
+        C.Encoder.add_tree enc t;
+        C.Encoder.to_string enc
+      in
+
+      let decoded =
+        let dec = C.Decoder.create_string encoded in
+        C.Decoder.read_tree dec
+      in
+
+      (* Printf.eprintf "encoded: h'%s'\n%!" (hex_of_string encoded); *)
+      if not @@ Util_tree.equal t decoded then
+        Q.Test.fail_reportf
+          "initial: %a@ decoded(encoded(.)): %a@ raw-encoded h'%s'" C.Tree.pp t
+          C.Tree.pp decoded (hex_of_string encoded);
+
+      true)
+
+let () =
+  add_qtest ~name:"refencode_then_decode" ~count:1000 arb_tree (fun t ->
+      let encoded = CBRef.encode (Util_tree.to_ref t) in
+
+      let decoded =
+        let dec = C.Decoder.create_string encoded in
+        C.Decoder.read_tree dec
+      in
+
+      (* Printf.eprintf "encoded: h'%s'\n%!" (hex_of_string encoded); *)
+      if not @@ Util_tree.equal t decoded then
+        Q.Test.fail_reportf
+          "initial: %a@ decoded(refencoded(.)): %a@ raw-encoded h'%s'" C.Tree.pp
+          t C.Tree.pp decoded (hex_of_string encoded);
+
+      true)
+
+let () =
+  Option.iter
+    (fun s -> QCheck_base_runner.set_seed (int_of_string s))
+    (Sys.getenv_opt "SEED");
+  QCheck_base_runner.run_tests_main (List.rev !qsuite)

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -111,12 +111,32 @@ let gen_tree : C.Tree.t Q.Gen.t =
     in
     let rec_ =
       [
-        (1, array_size (0 -- 15) (self_ (depth / 2)) >|= fun a -> T.Array a);
         ( 1,
-          array_size (0 -- 15) (pair (self_ 0) (self_ (depth / 3))) >|= fun m ->
+          0 -- 129 >>= fun size ->
+          let depth =
+            if size < 5 then
+              depth - 1
+            else if size < 30 then
+              depth / 2
+            else
+              0
+          in
+          array_size (return size) (self_ depth) >|= fun a -> T.Array a );
+        ( 1,
+          0 -- 129 >>= fun size ->
+          let depth =
+            if size < 5 then
+              depth - 1
+            else if size < 30 then
+              depth / 2
+            else
+              0
+          in
+          array_size (return size) (pair (self_ 0) (self_ depth)) >|= fun m ->
           T.Map m );
         ( 1,
-          0 -- 500 >>= fun tag ->
+          int >>= fun tag ->
+          let tag = abs tag in
           self_ (depth - 1) >|= fun sub -> T.Tag (tag, sub) );
       ]
     in


### PR DESCRIPTION
- perf: twice as faster encoding
- avoid allocs in benchmark
- fixes, add `Encoder.{to_string, add_tree}
- some property tests
- script to run benchs
- add decode bench
- bench
- add Tree.Int to reduce allocs
- test: extend scope of random gen
- cleanup decoder
- a bit more testing
